### PR TITLE
Replace pytz with zoneinfo and drop Python 3.8 support

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/run_all_tests_multiplatform.yml
+++ b/.github/workflows/run_all_tests_multiplatform.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/run_all_tests_multiplatform.yml
+++ b/.github/workflows/run_all_tests_multiplatform.yml
@@ -25,22 +25,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.8-minimum      , requirements: minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: linux-python3.8              , requirements: pinned     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: linux-python3.9-minimum      , requirements: minimum    , python-ver: "3.9" , os: ubuntu-latest }
           - { name: linux-python3.9              , requirements: pinned     , python-ver: "3.9" , os: ubuntu-latest }
           - { name: linux-python3.10             , requirements: pinned     , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , requirements: pinned     , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , requirements: pinned     , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.12-upgraded    , requirements: upgraded   , python-ver: "3.12", os: ubuntu-latest }
-          - { name: windows-python3.8-minimum    , requirements: minimum    , python-ver: "3.8" , os: windows-latest }
-          - { name: windows-python3.8            , requirements: pinned     , python-ver: "3.8" , os: windows-latest }
+          - { name: windows-python3.9-minimum    , requirements: minimum    , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.9            , requirements: pinned     , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.10           , requirements: pinned     , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , requirements: pinned     , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , requirements: pinned     , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.12-upgraded  , requirements: upgraded   , python-ver: "3.12", os: windows-latest }
-          - { name: macos-python3.8-minimum      , requirements: minimum    , python-ver: "3.8" , os: macos-latest }
-          - { name: macos-python3.8              , requirements: pinned     , python-ver: "3.8" , os: macos-latest }
+          - { name: macos-python3.9-minimum      , requirements: minimum    , python-ver: "3.9" , os: macos-latest }
           - { name: macos-python3.9              , requirements: pinned     , python-ver: "3.9" , os: macos-latest }
           - { name: macos-python3.10             , requirements: pinned     , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , requirements: pinned     , python-ver: "3.11", os: macos-latest }

--- a/.github/workflows/run_all_tests_on_conda.yml
+++ b/.github/workflows/run_all_tests_on_conda.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/run_all_tests_on_conda.yml
+++ b/.github/workflows/run_all_tests_on_conda.yml
@@ -25,8 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.8-minimum    , requirements: minimum    , python-ver: "3.8" , os: ubuntu-latest }
-          - { name: conda-linux-python3.8            , requirements: pinned     , python-ver: "3.8" , os: ubuntu-latest }
+          - { name: conda-linux-python3.9-minimum    , requirements: minimum    , python-ver: "3.9" , os: ubuntu-latest }
           - { name: conda-linux-python3.9            , requirements: pinned     , python-ver: "3.9" , os: ubuntu-latest }
           - { name: conda-linux-python3.10           , requirements: pinned     , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.11           , requirements: pinned     , python-ver: "3.11", os: ubuntu-latest }

--- a/examples/blood_oxygenation.py
+++ b/examples/blood_oxygenation.py
@@ -1,7 +1,6 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import ProcessingModule
 from ndx_wearables import WearableDevice, WearableTimeSeries

--- a/examples/create-physio-measure-demo.py
+++ b/examples/create-physio-measure-demo.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
+from zoneinfo import ZoneInfo
 from pynwb import NWBHDF5IO
 from pynwb.file import ProcessingModule
 from pathlib import Path
@@ -13,7 +13,7 @@ from ndx_wearables import WearableDevice, WearableTimeSeries, WearableEvents, Ph
 nwbfile = NdxEventsNWBFile(
     session_description="Example wearables study session",
     identifier='TEST_WEARABLES',
-    session_start_time=datetime.now(pytz.timezone('America/Chicago')),
+    session_start_time=datetime.now(ZoneInfo('America/Chicago')),
 )
 
 # generate fake wearables data

--- a/examples/daily_step_count.py
+++ b/examples/daily_step_count.py
@@ -1,7 +1,6 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import ProcessingModule
 from ndx_wearables import WearableDevice, WearableTimeSeries

--- a/examples/ember_example.py
+++ b/examples/ember_example.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
+from zoneinfo import ZoneInfo
 from pynwb import NWBFile, NWBHDF5IO
 import pandas as pd
 from pynwb.file import ProcessingModule
@@ -13,7 +13,7 @@ from pynwb.file import Subject
 
 def main():
 
-    now = datetime.now(pytz.timezone('America/new_york'))
+    now = datetime.now(ZoneInfo('America/New_York'))
     subjectid = f'synthetic-pre-release-0-2'
 
     nwb = NWBFile("NDX Wearables Example", "pre-release-0-2_2025-11", now)

--- a/examples/heart_rate_variability_(hrv).py
+++ b/examples/heart_rate_variability_(hrv).py
@@ -1,7 +1,6 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import ProcessingModule
 from ndx_wearables import WearableDevice, WearableTimeSeries

--- a/examples/sleep_movement_levels.py
+++ b/examples/sleep_movement_levels.py
@@ -1,7 +1,6 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import ProcessingModule
 from ndx_wearables import WearableDevice, WearableTimeSeries

--- a/examples/sleep_phases.py
+++ b/examples/sleep_phases.py
@@ -1,7 +1,6 @@
 
 import numpy as np
 from datetime import datetime
-import pytz
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.file import ProcessingModule
 from ndx_wearables import WearableDevice, WearableEnumSeries

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,11 @@ authors = [
 ]
 description = "Store data from human wearables"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "BSD-3"}
 classifiers = [
     # TODO: add classifiers before release
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/src/pynwb/tests/conftest.py
+++ b/src/pynwb/tests/conftest.py
@@ -1,19 +1,19 @@
-import pytz
 import pytest
 from pathlib import Path
 from datetime import datetime
+from zoneinfo import ZoneInfo
 from pynwb.file import ProcessingModule
 from ndx_events import NdxEventsNWBFile
 from ndx_wearables import WearableDevice
 
 
 def make_wearables_nwbfile(identifier=None):
-    now = datetime.now(pytz.timezone('America/Chicago'))
+    now = datetime.now(ZoneInfo('America/Chicago'))
     identifier = identifier if identifier else 'TEST_WEARABLES_'+now.strftime("%H%M%S")
     nwbfile = NdxEventsNWBFile(
         session_description="Example wearables study session created at "+now.strftime("%H%M%S"),
         identifier=identifier,
-        session_start_time=datetime.now(pytz.timezone('America/Chicago')),
+        session_start_time=datetime.now(ZoneInfo('America/Chicago')),
     )
 
     # create processing module

--- a/src/pynwb/tests/test_wearables_infrastructure.py
+++ b/src/pynwb/tests/test_wearables_infrastructure.py
@@ -5,7 +5,7 @@ Note, tests expect to be run from the ndc-wearables root directory
 
 import numpy as np
 from datetime import datetime
-import pytz
+from zoneinfo import ZoneInfo
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.base import TimeSeries
 from pynwb.file import ProcessingModule


### PR DESCRIPTION
## Summary

Fixes #42

- Replace `pytz.timezone()` with `ZoneInfo()` from the standard library `zoneinfo` module
- Remove unused `pytz` imports from example files
- Update `requires-python` from `>=3.8` to `>=3.9`
- Remove Python 3.8 from package classifiers
- Remove Python 3.8 from CI test matrix
- Add synchronize trigger to PR workflows because they were not being triggered after I made a new commit after opening a PR

## Background

Starting January 21, 2026, the `pytz` package is no longer installed as a transitive dependency (likely due to pandas 3.0 or packaging 26.0 releases), causing the test suite to fail with `ModuleNotFoundError: No module named 'pytz'`.

Rather than adding `pytz` as a direct dependency, this PR modernizes the codebase by:

1. **Using `zoneinfo`**: The `zoneinfo` module was added to the Python standard library in Python 3.9 and is the recommended modern approach for timezone handling. It requires no external dependencies.

2. **Dropping Python 3.8 support**: Python 3.8 reached end-of-life in October 2024. Dropping support allows us to use `zoneinfo` without needing the `backports.zoneinfo` package.