### PR TITLE
Fix some code issues found during review

### DIFF
--- a/src/pynwb/ndx_wearables/__init__.py
+++ b/src/pynwb/ndx_wearables/__init__.py
@@ -23,22 +23,6 @@ if not os.path.exists(__spec_path):
 # Load the namespace
 load_namespaces(str(__spec_path))
 
-# TODO: Define your classes here to make them accessible at the package level.
-# Safe fallback if the namespace was not found in original logic
-import pathlib
-if not os.path.exists(__spec_path):
-    print("Namespace not found in the default paths, trying fallback...")
-    
-    # Get the location of this file
-    fallback_path = pathlib.Path(__file__).parent / "ndx-wearables.namespace.yaml"
-
-    # Try to load from the fallback path
-    if os.path.exists(fallback_path):
-        print(f"Namespace found in fallback path: {fallback_path}")
-        load_namespaces(str(fallback_path))
-    else:
-        print(f"Namespace not found in fallback path: {fallback_path}")
-
 # Import the base classes
 from .wearables_classes import *
 

--- a/src/pynwb/ndx_wearables/wearables_classes.py
+++ b/src/pynwb/ndx_wearables/wearables_classes.py
@@ -6,7 +6,6 @@ from pynwb.base import TimeSeries
 from ndx_events import EventsTable
 from hdmf.utils import docval, popargs, get_docval, getargs  # <-- added getargs
 import numpy as np
-from enum import Enum
 from hdmf.common import DynamicTable
 
 from ndx_wearables.categorical_enums import ENUM_MAP

--- a/src/pynwb/tests/conftest.py
+++ b/src/pynwb/tests/conftest.py
@@ -31,10 +31,9 @@ def add_wearables_device(nwbfile):
     nwbfile.add_device(device)
 
     return nwbfile, device
-@pytest.fixture(scope='session')
-def tmp_path():
-    return Path('./examples/test_nwb_file.nwb')
-    #return Path('./src/pynwb/tests/test_nwb_file.nwb')
+@pytest.fixture
+def nwb_file_path(tmp_path):
+    return tmp_path / 'test_nwb_file.nwb'
 
 @pytest.fixture(scope='session')
 def wearables_nwbfile():

--- a/src/pynwb/tests/test_wearables_infrastructure.py
+++ b/src/pynwb/tests/test_wearables_infrastructure.py
@@ -137,11 +137,11 @@ def nwb_with_wearable_ts(wearables_nwbfile_device):
     return nwbfile
 
 @pytest.fixture
-def write_nwb_with_wearable_timeseries(tmp_path, nwb_with_wearable_ts):
-    with NWBHDF5IO(tmp_path, 'w') as io:
+def write_nwb_with_wearable_timeseries(nwb_file_path, nwb_with_wearable_ts):
+    with NWBHDF5IO(nwb_file_path, 'w') as io:
         io.write(nwb_with_wearable_ts)
 
-    return tmp_path
+    return nwb_file_path
 
 @pytest.fixture
 def nwb_with_wearable_events(wearables_nwbfile_device):
@@ -151,11 +151,11 @@ def nwb_with_wearable_events(wearables_nwbfile_device):
 
 
 @pytest.fixture
-def write_nwb_with_wearable_events(tmp_path, nwb_with_wearable_events):
-    with NWBHDF5IO(tmp_path, 'w') as io:
+def write_nwb_with_wearable_events(nwb_file_path, nwb_with_wearable_events):
+    with NWBHDF5IO(nwb_file_path, 'w') as io:
         io.write(nwb_with_wearable_events)
 
-    return tmp_path
+    return nwb_file_path
 
 @pytest.fixture
 def nwb_with_wearable_enum(wearables_nwbfile_device):
@@ -170,18 +170,18 @@ def nwb_with_physiological_measure(wearables_nwbfile_device):
     return nwbfile
 
 @pytest.fixture
-def write_nwb_with_wearable_enum(tmp_path, nwb_with_wearable_enum):
-    with NWBHDF5IO(tmp_path, 'w') as io:
+def write_nwb_with_wearable_enum(nwb_file_path, nwb_with_wearable_enum):
+    with NWBHDF5IO(nwb_file_path, 'w') as io:
         io.write(nwb_with_wearable_enum)
 
-    return tmp_path
+    return nwb_file_path
 
 @pytest.fixture
-def write_nwb_with_physiological_measure(tmp_path, nwb_with_physiological_measure):
-    with NWBHDF5IO(tmp_path, 'w') as io:
+def write_nwb_with_physiological_measure(nwb_file_path, nwb_with_physiological_measure):
+    with NWBHDF5IO(nwb_file_path, 'w') as io:
         io.write(nwb_with_physiological_measure)
 
-    return tmp_path
+    return nwb_file_path
 
 
 def test_wearables_timeseries(write_nwb_with_wearable_timeseries):

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -9,7 +9,7 @@ def main():
     # these arguments were auto-generated from your cookiecutter inputs
     ns_builder = NWBNamespaceBuilder(
         name="""ndx-wearables""",
-        version="""0.1.1""",
+        version="""0.2.1""",
         doc="""Store data from human wearable devices in NWB""",
         author=[
             "Tomasz M. Fraczek",

--- a/src/spec/wearables_infrastructure.py
+++ b/src/spec/wearables_infrastructure.py
@@ -1,5 +1,4 @@
-from networkx.utils.misc import groups
-from pynwb.spec import NWBGroupSpec, NWBDatasetSpec, NWBNamespaceBuilder, NWBAttributeSpec, RefSpec, LinkSpec
+from pynwb.spec import NWBGroupSpec, NWBDatasetSpec, NWBAttributeSpec, LinkSpec
 
 
 def make_wearables_infrastructure():


### PR DESCRIPTION
## Summary

- Fix version mismatch in `create_extension_spec.py` (hardcoded `0.1.1` while namespace and pyproject.toml are at `0.2.1`); regenerating specs would silently regress the version
- Remove dead/unreachable fallback block in `__init__.py` (the `load_namespaces()` call above already raises on invalid path, so the fallback with debug `print()` statements is never reached)
- Remove unused `from networkx.utils.misc import groups` import in `wearables_infrastructure.py` which adds a spurious undeclared dependency that would crash in a clean environment
- Fix `tmp_path` test fixture that shadows pytest's built-in, wrote test artifacts into `examples/`, and required running tests from a specific working directory
- Remove unused `Enum` import from `wearables_classes.py`

## Test plan

- [ ] Verify `pytest src/pynwb/tests/` passes (the `tmp_path` fixture rename is the only behavioral change)
- [ ] Verify `python src/spec/create_extension_spec.py` produces specs with version `0.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
